### PR TITLE
Allow building with base-4.8.0.0

### DIFF
--- a/examples/Service.hs
+++ b/examples/Service.hs
@@ -17,16 +17,16 @@ main = scotty 3000 $ do
 
   let tab :: Table Row
       tab = HashMap.fromList $
-      	    [("foo",HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("age", Number 21)])
-	    ,("abc",HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("bla",Bool True)])
-	    ] ++
-	    [ ("abc-" <> pack (show n),HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("bla",Bool False)])
-	    | n <- [1..100]
-	    ]
+            [("foo",HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("age", Number 21)])
+            ,("abc",HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("bla",Bool True)])
+            ] ++
+            [ ("abc-" <> pack (show n),HashMap.fromList [("firstname", "Roger"),("lastname","Rabbit"),("bla",Bool False)])
+            | n <- [1..100::Int]
+            ]
 
   users  <- liftIO $ actorCRUD 
-  	    	      (\ _ -> return ())	-- do not store the updates anywhere
-	      tab     	     		-- but supply an (updatable) table
+                      (\ _ -> return ())    -- do not store the updates anywhere
+                      tab                   -- but supply an (updatable) table
 
   scottyCRUD "/users" users
 

--- a/scotty-crud.cabal
+++ b/scotty-crud.cabal
@@ -23,8 +23,8 @@ library
                        TypeSynonymInstances
   build-depends:       aeson                >= 0.7  && < 0.9,
                        attoparsec           >= 0.11 && < 0.13,
-                       base                 >= 4.6  && < 4.8,
-                       bytestring           >=0.10  && < 0.11,
+                       base                 >= 4.6  && < 4.9,
+                       bytestring           >= 0.10 && < 0.11,
                        http-types           >= 0.8.5,
                        scotty               >= 0.8  && < 0.10,
                        stm                  >= 2.4  && < 2.5,
@@ -66,7 +66,7 @@ Test-Suite test-crud
                        TypeOperators,
                        TypeSynonymInstances
     build-depends:     aeson                >= 0.7  && < 0.9,
-                       base                 >= 4.6  && < 4.8,
+                       base                 >= 4.6  && < 4.9,
                        directory            >= 1.2  && < 1.3,
                        QuickCheck           >= 2.7  && < 2.8,
                        scientific           == 0.3.*,

--- a/src/Web/Scotty/CRUD/JSON.hs
+++ b/src/Web/Scotty/CRUD/JSON.hs
@@ -61,9 +61,9 @@ import           Web.Scotty.CRUD
 --   starts with the given table, and sends update events
 --   to the provided higher-order update function.
 
-actorCRUD :: (TableUpdate row -> IO ())	   
-	 -> Table row	-- initial Table row
-	 -> IO (CRUD row)
+actorCRUD :: (TableUpdate row -> IO ()) 
+         -> Table row   -- initial Table row
+         -> IO (CRUD row)
 actorCRUD push env = do
 
     table <- newTVarIO env

--- a/tests/Core.hs
+++ b/tests/Core.hs
@@ -1,8 +1,10 @@
-{-# LANGUAGE OverloadedStrings, ScopedTypeVariables, TypeOperators, TypeFamilies, TypeSynonymInstances, FlexibleInstances, GADTs #-}
+{-# LANGUAGE CPP, OverloadedStrings, ScopedTypeVariables, TypeOperators, TypeFamilies, TypeSynonymInstances, FlexibleInstances, GADTs #-}
 
 module Main where
 
+#if !(MIN_VERSION_base(4,8,0))
 import           Control.Applicative
+#endif
 --TMP
 import           Control.Concurrent (threadDelay)
 import           Control.Monad

--- a/tools/Main.hs
+++ b/tools/Main.hs
@@ -170,7 +170,7 @@ delta db db_new = do
     new  :: Table Row <- openFile db_new ReadMode >>= readTable
     let iDs = HashMap.keys old ++ [ k | k <- HashMap.keys new, not (k `HashMap.member` old) ]
     sequence_ [ case (HashMap.lookup iD old,HashMap.lookup iD new) of
-   	      	  (lhs,rhs) | lhs == rhs -> return ()
+                  (lhs,rhs) | lhs == rhs -> return ()
                   (_,     Just n)   -> writeTableUpdate stdout (RowUpdate (Named iD n :: Named Row))
                   (Just _,Nothing)  -> writeTableUpdate stdout (RowDelete iD :: TableUpdate Row)
                   (Nothing,Nothing) -> error "internal error"


### PR DESCRIPTION
Bump up `base`'s upper version bounds (and fix warnings that arise with GHC 7.10).
